### PR TITLE
delete job definition after job is submitted

### DIFF
--- a/submit/submit.go
+++ b/submit/submit.go
@@ -259,6 +259,7 @@ $BATCH_SCRIPT
 	if err != nil {
 		panic(errors.Wrap(err, "error registering job definition"))
 	}
+	defer deleteJobDefinition(b, ro)
 	var deps []*batch.JobDependency
 	for _, dep := range cli.DependsOn {
 		deps = append(deps, &batch.JobDependency{JobId: aws.String(dep)})
@@ -304,4 +305,16 @@ $BATCH_SCRIPT
 		panic(errors.Wrap(err, "error submitting job"))
 	}
 	fmt.Println(*resp.JobId)
+}
+
+func deleteJobDefinition(b *batch.Batch, jdef *batch.RegisterJobDefinitionOutput) error {
+	jobDefToDelete := fmt.Sprintf("%s:%d", *jdef.JobDefinitionName, *jdef.Revision)
+	input := &batch.DeregisterJobDefinitionInput{
+		JobDefinition: aws.String(jobDefToDelete),
+	}
+	_, err := b.DeregisterJobDefinition(input)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/submit/submit.go
+++ b/submit/submit.go
@@ -259,6 +259,8 @@ $BATCH_SCRIPT
 	if err != nil {
 		panic(errors.Wrap(err, "error registering job definition"))
 	}
+	// Ignore return value; there's not much we can do if it fails
+	// (and we're no worse off than before.)
 	defer deleteJobDefinition(b, ro)
 	var deps []*batch.JobDependency
 	for _, dep := range cli.DependsOn {
@@ -313,8 +315,5 @@ func deleteJobDefinition(b *batch.Batch, jdef *batch.RegisterJobDefinitionOutput
 		JobDefinition: aws.String(jobDefToDelete),
 	}
 	_, err := b.DeregisterJobDefinition(input)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }


### PR DESCRIPTION
This avoids the proliferation of job definitions that are used only once. At my institute, with potentially hundreds of users sharing the same AWS Batch account, not having this could create a huge number of job definitions. 